### PR TITLE
Update jenkins_password_spraying.py

### DIFF
--- a/password_spraying/jenkins_password_spraying.py
+++ b/password_spraying/jenkins_password_spraying.py
@@ -11,7 +11,7 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 # UTILS ########################################################################
 def try_login(auth):
-    r = SESSION.post(URL + '/j_acegi_security_check', data=auth, verify=False)
+    r = SESSION.post(URL + '/j_spring_security_check', data=auth, verify=False)
 
     if r.status_code == 200:
         return True


### PR DESCRIPTION
Since Jenkins updated the security framework to spring (since version 2.266), the POST URL is different now
Before: "URL + '/j_acegi_security_check'"
Now: "URL + '/j_spring_security_check'"
The login parameters are still the same "j_username" and "j_password"
I have verified this works on the latest version 2.266
https://www.jenkins.io/changelog/